### PR TITLE
STREAM-9 refine home page layout to dynamically size

### DIFF
--- a/src/FilmDesc.jsx
+++ b/src/FilmDesc.jsx
@@ -1,23 +1,26 @@
-function FilmRating({rating}) {
-
+function FilmRating({ rating }) {
   const ratingSrc = "/assets/mpaa-" + rating + ".svg";
 
-  return <img src={ratingSrc} alt={rating} 
-  style={{
-    height: "1em",      // Matches the font size of surrounding text
-    width: "auto", // Maintains aspect ratio
-    verticalAlign: "middle",  // Aligns nicely with text baseline
-    marginLeft: "0.25em",     // Optional spacing
-    marginRight: "0.25em",
-  }}/>
+  return (
+    <img
+      src={ratingSrc}
+      alt={rating}
+      style={{
+        height: "1em",
+        width: "auto",
+        verticalAlign: "middle",
+        marginLeft: "0.25em",
+        marginRight: "0.25em",
+      }}
+    />
+  );
 }
 
-
 export default function FilmDesc() {
-
-  let movieTitle = "A Minecraft Movie";
+  let title = "A Minecraft Movie";
   let runTime = "1h 41m";
-  let description = "Four misfits are suddenly pulled through a mysterious portal into a bizarre cubic wonderland that thrives on imagination. To get back home they'll have to master this world while embarking on a quest with an unexpected expert crafter.";
+  let description =
+    "Four misfits are suddenly pulled through a mysterious portal into a bizarre cubic wonderland that thrives on imagination. To get back home they'll have to master this world while embarking on a quest with an unexpected expert crafter.";
   let rating = "pg";
   let year = "2025";
 
@@ -25,13 +28,14 @@ export default function FilmDesc() {
     <div className="container">
       <div className="row">
         <div className="col">
-          <h5>{movieTitle}</h5> <p>{year} <FilmRating rating={rating}/> {runTime}</p>
+          <h5>{title}</h5>{" "}
+          <p>
+            {year} <FilmRating rating={rating} /> {runTime}
+          </p>
         </div>
       </div>
       <div className="row">
-        <p>
-          {description}
-        </p>
+        <p>{description}</p>
       </div>
     </div>
   );

--- a/src/FilmDesc.jsx
+++ b/src/FilmDesc.jsx
@@ -16,7 +16,7 @@ function FilmRating({ rating }) {
   );
 }
 
-export default function FilmDesc() {
+export default function FilmDesc({ posterWidth }) {
   let title = "A Minecraft Movie";
   let runTime = "1h 41m";
   let description =
@@ -24,19 +24,37 @@ export default function FilmDesc() {
   let rating = "pg";
   let year = "2025";
 
+  // Define font sizes based on the width of the poster
+  const titleSize = Math.max(14, Math.min(posterWidth * 0.06, 20)); // between 14px and 20px
+  const textSize = Math.max(12, Math.min(posterWidth * 0.045, 16)); // between 12px and 16px
+
   return (
     <div className="container">
       <div className="row">
         <div className="col">
-          <h5>{title}</h5>{" "}
-          <p>
+          <p
+            style={{
+              fontSize: `${titleSize}px`,
+              fontWeight: "bold",
+              margin: 0,
+              lineHeight: 1.2,
+            }}
+          >
+            {title}
+          </p>
+          <p
+            style={{
+              fontSize: `${textSize}px`,
+              fontWeight: "normal",
+              margin: 0,
+              lineHeight: 1.2,
+            }}
+          >
             {year} <FilmRating rating={rating} /> {runTime}
           </p>
         </div>
       </div>
-      <div className="row">
-        <p>{description}</p>
-      </div>
+      <div className="row">{/*<p>{description}</p>*/}</div>
     </div>
   );
 }

--- a/src/Home.jsx
+++ b/src/Home.jsx
@@ -4,19 +4,36 @@ import ProductInfo from "./ProductInfo.jsx";
 import NavBar from "./NavBar.jsx";
 
 export default function Home() {
+  const promoTagline = "Responsive left-aligned hero with image";
+  const promoDescription =
+    "Quickly design and customize responsive mobile-first sites with Bootstrap, the worlds most popular front-end open source toolkit, featuring Sass variables and mixins, responsive grid system, extensive prebuilt components, and powerful JavaScript plugins.";
   return (
     <>
       <NavBar />
-      <div className="container-fluid d-flex justify-content-center pt-3">
-        <div className="d-flex flex-row align-items-start gap-5">
-          <div>
-            <ProductInfo />
-            <ProductInfo />
-            <ProductInfo />
-            <ProductInfo />
-          </div>
-          <div>
+      <div className="container col-xxl-8 px-4 py-2">
+        <div className="row flex-lg-row-reverse align-items-center g-5">
+          <div className="col-10 col-sm-8 col-lg-6">
             <Poster />
+          </div>
+          <div className="col-lg-6">
+            <h1 className="display-5 fw-bold text-body-emphasis lh-1 mb-3">
+              {promoTagline}
+            </h1>
+            <p className="lead">{promoDescription}</p>
+            <div className="d-grid gap-2 d-md-flex justify-content-md-start">
+              <button
+                type="button"
+                className="btn btn-primary btn-lg px-4 me-md-2"
+              >
+                Sign Up
+              </button>
+              <button
+                type="button"
+                className="btn btn-outline-secondary btn-lg px-4"
+              >
+                Learn More
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/src/Home.jsx
+++ b/src/Home.jsx
@@ -7,9 +7,9 @@ export default function Home() {
   return (
     <>
       <NavBar />
-      <div className="container-fluid d-flex justify-content-center align-items-center">
-        <div className="d-flex flex-row align-items-center gap-5">
-          <div className="d-flex flex-column align-items-center">
+      <div className="container-fluid d-flex justify-content-center pt-3">
+        <div className="d-flex flex-row align-items-start gap-5">
+          <div>
             <ProductInfo />
             <ProductInfo />
             <ProductInfo />

--- a/src/NavBar.jsx
+++ b/src/NavBar.jsx
@@ -1,21 +1,21 @@
-
 import React from "react";
-import {
-  Link
-} from "react-router-dom";
+import { Link } from "react-router-dom";
 
 export default function NavBar({ user, signOut }) {
   return (
     <nav className="navbar bg-body-tertiary">
       <div className="container-fluid">
         <a className="navbar-brand" href="#">
-          <img
-            src="/docs/5.3/assets/brand/bootstrap-logo.svg"
-            alt="Logo"
-            width="30"
-            height="24"
-            className="d-inline-block align-text-top"
-          />
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            fill="currentColor"
+            className="bi bi-app"
+            viewBox="0 0 16 16"
+          >
+            <path d="M11 2a3 3 0 0 1 3 3v6a3 3 0 0 1-3 3H5a3 3 0 0 1-3-3V5a3 3 0 0 1 3-3zM5 1a4 4 0 0 0-4 4v6a4 4 0 0 0 4 4h6a4 4 0 0 0 4-4V5a4 4 0 0 0-4-4z" />
+          </svg>
           Stream-App
         </a>
         <form className="d-flex">

--- a/src/Poster.jsx
+++ b/src/Poster.jsx
@@ -1,14 +1,25 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import FilmDesc from "./FilmDesc.jsx";
 import posterSrc from "./assets/a_minecraft_movie-p1640942.jpg";
 
 export default function Poster() {
-  // const { src } = "./assets/a_minecraft_movie-p1640942.jpg";
   const [dimensions, setDimensions] = useState({ height: 0, width: 0 });
+  const imgRef = useRef(null);
 
-  const handleImageLoad = (e) => {
-    const { offsetHeight, offsetWidth } = e.target;
-    setDimensions({ height: offsetHeight, width: offsetWidth });
+  const updateDimensions = () => {
+    if (imgRef.current) {
+      const { offsetHeight, offsetWidth } = imgRef.current;
+      setDimensions({ height: offsetHeight, width: offsetWidth });
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener("resize", updateDimensions);
+    return () => window.removeEventListener("resize", updateDimensions);
+  }, []);
+
+  const handleImageLoad = () => {
+    updateDimensions();
   };
 
   return (
@@ -22,6 +33,7 @@ export default function Poster() {
       >
         <h3 className="text-center">NOW SHOWING</h3>
         <img
+          ref={imgRef}
           src={posterSrc}
           style={{
             maxHeight: "80%",
@@ -31,7 +43,7 @@ export default function Poster() {
           alt="poster"
         />
         <div className="card-body">
-          <FilmDesc/>
+          <FilmDesc />
         </div>
       </div>
     </div>

--- a/src/Poster.jsx
+++ b/src/Poster.jsx
@@ -3,13 +3,21 @@ import FilmDesc from "./FilmDesc.jsx";
 import posterSrc from "./assets/a_minecraft_movie-p1640942.jpg";
 
 export default function Poster() {
-  const [dimensions, setDimensions] = useState({ height: 0, width: 0 });
+  const [dimensions, setDimensions] = useState({
+    height: 0,
+    width: 0,
+    preciseWidth: 0,
+  });
   const imgRef = useRef(null);
 
   const updateDimensions = () => {
     if (imgRef.current) {
-      const { offsetHeight, offsetWidth } = imgRef.current;
-      setDimensions({ height: offsetHeight, width: offsetWidth });
+      const { offsetHeight } = imgRef.current;
+      const { width: preciseWidth } = imgRef.current.getBoundingClientRect();
+      setDimensions({
+        height: offsetHeight,
+        width: Math.ceil(preciseWidth), // ✅ round up to avoid subpixel gap
+      });
     }
   };
 
@@ -28,21 +36,37 @@ export default function Poster() {
         className="card"
         style={{
           height: "calc(100vh - 80px)",
-          width: dimensions.width > 0 ? `${dimensions.width + 2}px` : "auto",
+          width: dimensions.width > 0 ? `${dimensions.width + 1}px` : "auto",
         }}
       >
-        <h3 className="text-center">NOW SHOWING</h3>
+        <h3
+          className="text-center mb-0"
+          style={{
+            height: "6%",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          NOW SHOWING
+        </h3>
+
         <img
           ref={imgRef}
           src={posterSrc}
           style={{
             maxHeight: "80%",
-            margin: "0 auto",
+            display: "block",
+            marginLeft: "auto",
+            marginRight: "auto",
           }}
           onLoad={handleImageLoad}
           alt="poster"
         />
-        <div className="card-body">
+        <div
+          className="card-body p-2"
+          style={{ height: "14%"}}
+        >
           <FilmDesc />
         </div>
       </div>

--- a/src/Poster.jsx
+++ b/src/Poster.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from "react";
+import { useElementHeight } from "./useElementHeight";
 import FilmDesc from "./FilmDesc.jsx";
 import posterSrc from "./assets/a_minecraft_movie-p1640942.jpg";
 
@@ -16,7 +17,7 @@ export default function Poster() {
       const { width: preciseWidth } = imgRef.current.getBoundingClientRect();
       setDimensions({
         height: offsetHeight,
-        width: Math.ceil(preciseWidth), // ✅ round up to avoid subpixel gap
+        width: Math.ceil(preciseWidth),
       });
     }
   };
@@ -30,19 +31,24 @@ export default function Poster() {
     updateDimensions();
   };
 
+  const [descRef, descHeight] = useElementHeight();
+  const [headerRef, headerHeight] = useElementHeight();
+
+  const maxImageHeight = `calc(100vh - 80px - ${headerHeight}px - ${descHeight}px)`;
+
   return (
     <div className="d-flex justify-content-center">
       <div
         className="card"
         style={{
-          height: "calc(100vh - 80px)",
+          height: "calc(100bh - 80px)",
           width: dimensions.width > 0 ? `${dimensions.width + 1}px` : "auto",
         }}
       >
         <h3
           className="text-center mb-0"
+          ref={headerRef}
           style={{
-            height: "6%",
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
@@ -55,7 +61,7 @@ export default function Poster() {
           ref={imgRef}
           src={posterSrc}
           style={{
-            maxHeight: "80%",
+            maxHeight: maxImageHeight,
             display: "block",
             marginLeft: "auto",
             marginRight: "auto",
@@ -63,11 +69,8 @@ export default function Poster() {
           onLoad={handleImageLoad}
           alt="poster"
         />
-        <div
-          className="card-body p-2"
-          style={{ height: "14%"}}
-        >
-          <FilmDesc />
+        <div className="card-body p-2" ref={descRef}>
+          <FilmDesc posterWidth={dimensions.width} />
         </div>
       </div>
     </div>

--- a/src/ProductInfo.jsx
+++ b/src/ProductInfo.jsx
@@ -1,9 +1,11 @@
 export default function ProductInfo() {
   return (
-    <div className="card m-3">
+    <div className="card mb-3">
       <div className="card-body">
         <h5 className="card-title">Card title</h5>
-        <h6 className="card-subtitle mb-2 text-body-secondary">Card subtitle</h6>
+        <h6 className="card-subtitle mb-2 text-body-secondary">
+          Card subtitle
+        </h6>
         <p className="card-text">
           Some quick example text to build on the card title and make up the
           bulk of the card content.

--- a/src/useElementHeight.js
+++ b/src/useElementHeight.js
@@ -1,0 +1,20 @@
+import { useState, useEffect, useRef } from "react";
+
+export function useElementHeight() {
+  const ref = useRef(null);
+  const [height, setHeight] = useState(0);
+
+  useEffect(() => {
+    const updateHeight = () => {
+      if (ref.current) {
+        setHeight(ref.current.clientHeight);
+      }
+    };
+
+    updateHeight();
+    window.addEventListener("resize", updateHeight);
+    return () => window.removeEventListener("resize", updateHeight);
+  }, []);
+
+  return [ref, height];
+}


### PR DESCRIPTION
- Fixes poster image scaling in *almost all situations
- Now showing and poster description size with the image, so no space wasted
- Removes synopsis from FilmDesc
- Changes left side promo to better looking & shorter hero
- BUG: image still overflows in weird small window sizes